### PR TITLE
Implement $FLOWERDATADIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,11 @@ Make sure the following are sourced
 Then
 ```bash
 export PATH=$FLOWERDIR/rootflower:$PATH
+export FLOWERDATADIR=/path/to/writable/directory/ #e.g. $FLOWERDIR/data/
 rootflower -b -q flower_with_bonsai.C+'("/path/to/wcsim/file.root",1,"SuperK")'
 ```
+
+Note that `$FLOWERDATADIR` is used to store information that takes a while to calculate, and that only needs to be done once per geometry (e.g. the nearest neighbours of each PMT). If `$FLOWERDATADIR` is not set, or set to a directory that doesn't exist, `$FLOWERDIR/data/` will be used instead
 
 ## Running in other code
 * Construct a class member, giving it a detectorname (it sets default values and determines the exact energy correction factors) and detector geometry

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -6,6 +6,7 @@
 
 #include "TFile.h"
 #include "TTree.h"
+#include "TSystem.h"
 
 using std::cout;
 using std::endl;
@@ -251,7 +252,7 @@ void WCSimFLOWER::FindMaxTimeInterval()
 
 void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
 {
-  TString fname = TString::Format("$FLOWERDIR/data/%s_%.5f.root", fDetectorName.c_str(), fNeighbourDistance);
+  TString fname = TString::Format("%s/%s_%.5f.root", GetFLOWERDataDir().Data(), fDetectorName.c_str(), fNeighbourDistance);
   TFile f(fname);
   TTree * t;
   int tubeID;
@@ -445,4 +446,14 @@ void WCSimFLOWER::CorrectEnergy()
   if(fVerbose) {
     std::cout << "Reconstructed energy = " << fERec << " MeV" << std::endl;
   }
+}
+
+TString WCSimFLOWER::GetFLOWERDataDir()
+{
+  TString dir(gSystem->Getenv("FLOWERDATADIR"));
+  if(!dir.Length() || !gSystem->OpenDirectory(dir.Data())) {
+    cout << "$FLOWERDATADIR not set, or points to directory that doesn't exist. Using $FLOWERDIR/data/" << endl;
+    dir = TString::Format("%s/data/", gSystem->Getenv("FLOWERDIR"));
+  }
+  return dir;
 }

--- a/WCSimFLOWER.h
+++ b/WCSimFLOWER.h
@@ -33,6 +33,8 @@ class WCSimFLOWER {
   void SetLongDuration(float longduration);
   void SetTopBottomDistance(float hi, float lo);
 
+  TString GetFLOWERDataDir();
+
  private:
   enum kDetector_t {kSuperK = 0, kHyperK40, kHyperK20};
 


### PR DESCRIPTION
For the case where the user can't write to `$FLOWERDIR/data` (e.g. from a singularity container) the user can write nearest neighbour information to an alternative place by setting `$FLOWERDATADIR`