### PR TITLE
Add PMT Mask support

### DIFF
--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -53,6 +53,42 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
     break;
+  case kHyperK20BnL0mPMT: // WCSim Hybrid 20% case
+    fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
+    fDarkRate2 = 0.; // dark rate of 7.5cm PMTs in mPMT modules
+    fNPMTs = 19418;   // total number of 50cm Box&Line PMTs
+    fNPMTs2 = 0; // total number of 7.5cm PMTs (10k mPMT modules, 19 PMTs each)
+    fNeighbourDistance = 145;
+    fTopBottomDistanceLo = 2670;
+    fTopBottomDistanceHi = 2690;
+    break;
+  case kHyperK40BnL0mPMT:
+    fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
+    fDarkRate2 = 0.; // dark rate of 7.5cm PMTs in mPMT modules
+    fNPMTs = 38952;   // total number of 50cm Box&Line PMTs
+    fNPMTs2 = 0; // total number of 7.5cm PMTs (10k mPMT modules, 19 PMTs each)
+    fNeighbourDistance = 145;
+    fTopBottomDistanceLo = 2670;
+    fTopBottomDistanceHi = 2690;
+    break;
+  case kHyperK20BnL3mPMT:
+    fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
+    fDarkRate2 = 0.3; // dark rate of 7.5cm PMTs in mPMT modules
+    fNPMTs = 20055;   // total number of 50cm Box&Line PMTs
+    fNPMTs2 = 54131; // total number of 7.5cm PMTs (10k mPMT modules, 19 PMTs each)
+    fNeighbourDistance = 145;
+    fTopBottomDistanceLo = 2670;
+    fTopBottomDistanceHi = 2690;
+    break;
+  case kHyperK20BnL5mPMT:
+    fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
+    fDarkRate2 = 0.3; // dark rate of 7.5cm PMTs in mPMT modules
+    fNPMTs = 18952;   // total number of 50cm Box&Line PMTs
+    fNPMTs2 = 89604; // total number of 7.5cm PMTs (10k mPMT modules, 19 PMTs each)
+    fNeighbourDistance = 145;
+    fTopBottomDistanceLo = 2670;
+    fTopBottomDistanceHi = 2690;
+    break;
   case kHyperK20BnL10mPMT:
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.3; // dark rate of 7.5cm PMTs in mPMT modules
@@ -192,6 +228,14 @@ WCSimFLOWER::kDetector_t WCSimFLOWER::DetectorEnumFromString(std::string name)
     return kSuperK;
   else if (!name.compare("HyperK_20perCent"))
     return kHyperK20;
+  else if (!name.compare("HyperK_20BnL0mPMT")) // TODO: name should be consistent with https://github.com/bquilain/WCSim/blob/hybridPMT/src/WCSimDetectorConfigs.cc
+    return kHyperK20BnL0mPMT;
+  else if (!name.compare("HyperK_40BnL0mPMT")) // TODO: name should be consistent with https://github.com/bquilain/WCSim/blob/hybridPMT/src/WCSimDetectorConfigs.cc
+    return kHyperK40BnL0mPMT;
+  else if (!name.compare("HyperK_20BnL3mPMT")) // TODO: name should be consistent with https://github.com/bquilain/WCSim/blob/hybridPMT/src/WCSimDetectorConfigs.cc
+    return kHyperK20BnL3mPMT;
+  else if (!name.compare("HyperK_20BnL5mPMT")) // TODO: name should be consistent with https://github.com/bquilain/WCSim/blob/hybridPMT/src/WCSimDetectorConfigs.cc
+    return kHyperK20BnL5mPMT;
   else if (!name.compare("HyperK_20BnL10mPMT")) // TODO: name should be consistent with https://github.com/bquilain/WCSim/blob/hybridPMT/src/WCSimDetectorConfigs.cc
     return kHyperK20BnL10mPMT;
   cerr << "DetectorEnumFromString() Unknown detector name: " << name << endl;
@@ -441,9 +485,20 @@ void WCSimFLOWER::GetNEff()
     photoCoverage = 1 / WCSimFLOWER::fEffCoverages[int(theta/10)]; // 1 over photocoverage, assuming SuperK or HyperK_40perCent
     if (fDetector == kHyperK20)
       photoCoverage *= 38448 / float(fNPMTs); // ratio of number of PMTs
+    if (fDetector == kHyperK20BnL0mPMT) {
+      photoCoverage *= 38952 / float(fNPMTs); // ratio of number of B&L PMTs
+    }
+    if (fDetector == kHyperK20BnL3mPMT) {
+      photoCoverage *= 38952 / float(fNPMTs); // ratio of number of B&L PMTs
+      photoCoverage /= 1.06; //  3k mPMT modules (19 PMTs, 3" diameter) have  6% the area of 20055 20-inch PMTs
+    }
+    if (fDetector == kHyperK20BnL5mPMT) {
+      photoCoverage *= 38952 / float(fNPMTs); // ratio of number of B&L PMTs
+      photoCoverage /= 1.11; //  5k mPMT modules (19 PMTs, 3" diameter) have 22% the area of 18952 20-inch PMTs
+    }
     if (fDetector == kHyperK20BnL10mPMT) {
-      photoCoverage *= 39238 / float(fNPMTs); // ratio of number of B&L PMTs
-      photoCoverage /= 1.22; // 10k mPMT modules (19 PMTs, 3" diameter) have 22% the area of 19462 20-inch PMTs
+      photoCoverage *= 38952 / float(fNPMTs); // ratio of number of B&L PMTs
+      photoCoverage /= 1.22; // 10k mPMT modules (19 PMTs, 3" diameter) have 22% the area of 19208 20-inch PMTs
     }
     // correct for scattering in water
     waterTransparency = exp(fDistanceShort[i] / fLambdaEff);

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -23,8 +23,7 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fVerbose(verbose),
     fGeom(geom),
     fLongDuration(100),
-    fShortDuration(50),
-    fQuiet(false)
+    fShortDuration(50)
 {
   switch (fDetector) {
   case kSuperK:
@@ -115,58 +114,58 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
 void WCSimFLOWER::SetDarkRate(float darkrate)
 {
   fDarkRate = darkrate;
-  if ( !fQuiet ) cout << "Setting DarkRate to " << fDarkRate << " kHz" << endl;
+  if (fVerbose >= 0) cout << "Setting DarkRate to " << fDarkRate << " kHz" << endl;
   fDarkRate /= 1000000; //convert to per ns
 }
 
 void WCSimFLOWER::SetDarkRate2(float darkrate)
 {
   fDarkRate2 = darkrate;
-  if ( !fQuiet ) cout << "Setting DarkRate to " << fDarkRate2 << " kHz" << endl;
+  if (fVerbose >= 0) cout << "Setting DarkRate to " << fDarkRate2 << " kHz" << endl;
   fDarkRate2 /= 1000000; //convert to per ns
 }
 
 void WCSimFLOWER::SetNPMTs(int npmts)
 {
   fNPMTs = npmts;
-  if ( !fQuiet ) cout << "Setting NPMTs to " << fNPMTs << endl;
+  if (fVerbose >= 0) cout << "Setting NPMTs to " << fNPMTs << endl;
 }
 
 void WCSimFLOWER::SetNPMTs2(int npmts)
 {
   fNPMTs2 = npmts;
-  if ( !fQuiet ) cout << "Setting NPMTs2 to " << fNPMTs2 << endl;
+  if (fVerbose >= 0) cout << "Setting NPMTs2 to " << fNPMTs2 << endl;
 }
 
 void WCSimFLOWER::SetNWorkingPMTs(int nworkingpmts)
 {
   fNWorkingPMTs = nworkingpmts;
-  if ( !fQuiet ) cout << "Setting NWorkingPMTs to " << fNWorkingPMTs << endl;
+  if (fVerbose >= 0) cout << "Setting NWorkingPMTs to " << fNWorkingPMTs << endl;
 }
 
 void WCSimFLOWER::SetNWorkingPMTs2(int nworkingpmts)
 {
   fNWorkingPMTs2 = nworkingpmts;
-  if ( !fQuiet ) cout << "Setting NWorkingPMTs2 to " << fNWorkingPMTs2 << endl;
+  if (fVerbose >= 0) cout << "Setting NWorkingPMTs2 to " << fNWorkingPMTs2 << endl;
 }
 
 void WCSimFLOWER::SetNeighbourDistance(float neighbour_distance, bool overwrite_nearest)
 {
   fNeighbourDistance = neighbour_distance;
-  if ( !fQuiet ) cout << "Setting NeighbourDistance to " << fNeighbourDistance << endl;
+  if (fVerbose >= 0) cout << "Setting NeighbourDistance to " << fNeighbourDistance << endl;
   GetNearestNeighbours(overwrite_nearest);
 }
 
 void WCSimFLOWER::SetShortDuration(float shortduration)
 {
   fShortDuration = shortduration;
-  if ( !fQuiet ) cout << "Setting ShortDuration to " << fShortDuration << " ns" << endl;
+  if (fVerbose >= 0) cout << "Setting ShortDuration to " << fShortDuration << " ns" << endl;
 }
 
 void WCSimFLOWER::SetLongDuration(float longduration)
 {
   fLongDuration = longduration;
-  if ( !fQuiet ) cout << "Setting LongDuration to " << fLongDuration << " ns" << endl;
+  if (fVerbose >= 0) cout << "Setting LongDuration to " << fLongDuration << " ns" << endl;
 }
 
 void WCSimFLOWER::SetTopBottomDistance(float hi, float lo)

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -15,7 +15,8 @@ using std::cerr;
 const float WCSimFLOWER::fEffCoverages[9] = {0.4, 0.4, 0.4, 0.4, 0.4068, 0.4244, 0.4968, 0.5956, 0.67}; // from MC: coverage at theta = 5, 15, ..., 85 degree
 const int FIRST_PMT2 = 100000;
 
-WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool overwrite_nearest, int verbose)
+
+WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool overwrite_nearest, int verbose, std::vector<bool> masked_pmts)
   : fLightGroupSpeed(21.58333), // speed of light in water (in cm/ns), value from https://github.com/hyperk/hk-BONSAI/blob/d9b227dad26fb63f2bfe80f60f7f58b5a703250a/bonsai/hits.h#L5
     fLambdaEff(100*100), // scattering length in cm (based on Design Report II.2.E.1)
     fDetectorName(detectorname),
@@ -23,14 +24,17 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fVerbose(verbose),
     fGeom(geom),
     fLongDuration(100),
-    fShortDuration(50)
+    fShortDuration(50),
+    fMaskedPMTs(masked_pmts)
 {
   switch (fDetector) {
   case kSuperK:
     fDarkRate = 4.2;
     fDarkRate2 = 0;
     fNPMTs = 11146;
+    fNPMTs_nomask = 11146;
     fNPMTs2 = 0;
+    fNPMTs2_nomask = 0;
     fNeighbourDistance = 102;
     fTopBottomDistanceLo = 1767;
     fTopBottomDistanceHi = 1768;
@@ -39,7 +43,9 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fDarkRate = 8.4;
     fDarkRate2 = 0;
     fNPMTs = 38448;
+    fNPMTs_nomask = 38448;
     fNPMTs2 = 0;
+    fNPMTs2_nomask = 0;
     fNeighbourDistance = 102;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
@@ -48,7 +54,9 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fDarkRate = 8.4;
     fDarkRate2 = 0;
     fNPMTs = 19462;
+    fNPMTs_nomask = 19462;
     fNPMTs2 = 0;
+    fNPMTs2_nomask = 0;
     fNeighbourDistance = 145;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
@@ -57,7 +65,9 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.; // dark rate of 7.5cm PMTs in mPMT modules
     fNPMTs = 19208;   // total number of 50cm Box&Line PMTs
+    fNPMTs_nomask = 19208; // true number of 50cm cm PMTs in the files (for PMT Id check).
     fNPMTs2 = 0; // total number of 7.5cm PMTs (0k mPMT modules, 19 PMTs each)
+    fNPMTs2_nomask = 0; // true number of 7.5 cm PMTs in the files (for PMT Id check). Actually 182704 here, but FLOWER should not see any hit from these PMTs
     fNeighbourDistance = 145;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
@@ -66,7 +76,9 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.; // dark rate of 7.5cm PMTs in mPMT modules
     fNPMTs = 38952;   // total number of 50cm Box&Line PMTs
+    fNPMTs_nomask = 38952; // true number of 50cm cm PMTs in the files (for PMT Id check).
     fNPMTs2 = 0; // total number of 7.5cm PMTs (0k mPMT modules, 19 PMTs each)
+    fNPMTs2_nomask = 0; // true number of 7.5 cm PMTs in the files (for PMT Id check). 
     fNeighbourDistance = 102;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
@@ -75,7 +87,9 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.3; // dark rate of 7.5cm PMTs in mPMT modules
     fNPMTs = 19208;   // total number of 50cm Box&Line PMTs
+    fNPMTs_nomask = 19208; // true number of 50cm cm PMTs in the files (for PMT Id check).
     fNPMTs2 = 54853; // total number of 7.5cm PMTs (3k mPMT modules, 19 PMTs each)
+    fNPMTs2_nomask = 182704; // true number of 7.5 cm PMTs in the files (for PMT Id check). 
     fNeighbourDistance = 145;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
@@ -84,7 +98,9 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.3; // dark rate of 7.5cm PMTs in mPMT modules
     fNPMTs = 19208;   // total number of 50cm Box&Line PMTs
+    fNPMTs_nomask = 19208; // true number of 50cm cm PMTs in the files (for PMT Id check).
     fNPMTs2 = 91352; // total number of 7.5cm PMTs (5k mPMT modules, 19 PMTs each)
+    fNPMTs2_nomask = 182704; // true number of 7.5 cm PMTs in the files (for PMT Id check). 
     fNeighbourDistance = 145;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
@@ -93,7 +109,9 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.3; // dark rate of 7.5cm PMTs in mPMT modules
     fNPMTs = 19208;   // total number of 50cm Box&Line PMTs
+    fNPMTs_nomask = 19208; // true number of 50cm cm PMTs in the files (for PMT Id check).
     fNPMTs2 = 182704; // total number of 7.5cm PMTs (10k mPMT modules, 19 PMTs each)
+    fNPMTs2_nomask = 182704; // true number of 7.5 cm PMTs in the files (for PMT Id check). 
     fNeighbourDistance = 145;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
@@ -105,8 +123,20 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
   }
 
   fNallPMTs = fNPMTs;
+  fNallPMTs_nomask = fNPMTs_nomask;
+  
   if (fNPMTs2 > 0)
     fNallPMTs = FIRST_PMT2 + fNPMTs2;
+  if (fNPMTs2_nomask > 0)
+    fNallPMTs_nomask = FIRST_PMT2 + fNPMTs2_nomask;
+    
+  if ( fMaskedPMTs.size() == 0 ) {
+    fMaskedPMTs.resize(fNallPMTs_nomask,false);
+  }
+  else if ( fMaskedPMTs.size() < fNallPMTs_nomask ) {
+    cerr << "Masked PMT list is invalid " << fMaskedPMTs.size() << " < " << fNallPMTs_nomask << endl;
+    exit(-1);
+  }
 
   cout << "Using default values for detector " << fDetectorName << " " << fDetector << endl;
 
@@ -142,6 +172,7 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
   fDistance            .reserve(fNallPMTs);
   fTimesCorrected      .reserve(fNallPMTs);
   fTimesCorrectedSorted.reserve(fNallPMTs);
+  
 
   GetNearestNeighbours(overwrite_nearest);
 }
@@ -325,7 +356,7 @@ void WCSimFLOWER::FindMaxTimeInterval()
     if(fTimesCorrected[i] >= fStartTime && fTimesCorrected[i] < (fStartTime + fShortDuration)) {
       fDistanceShort[j] = fDistance[i];
       fTubeIdsShort [j] = fTubeIds [i];
-      if (fTubeIdsShort[j] <= 0 || fTubeIdsShort[j] > fNallPMTs || (fTubeIdsShort[j] > fNPMTs && fTubeIdsShort[j] < FIRST_PMT2))
+      if (fTubeIdsShort[j] <= 0 || fTubeIdsShort[j] > fNallPMTs_nomask || (fTubeIdsShort[j] > fNPMTs_nomask && fTubeIdsShort[j] < FIRST_PMT2))
         cerr << "fTubeIdsShort has picked up an invalid ID: " << fTubeIdsShort[j] << endl
              << "Are you using the correct input file / geometry option combination" << endl;
       j++;
@@ -377,7 +408,7 @@ void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
     int tubeID_j;
     float x, y, z;
     // Loop over 50cm PMTs to find their neighbours (don't search for neighbours of mPMTs, see https://github.com/HKDAQ/FLOWER/issues/12)
-    for (unsigned int ipmt = 0; ipmt < fNPMTs; ipmt++) {
+    for (unsigned int ipmt = 0; ipmt < fNPMTs_nomask; ipmt++) {        
       if(fVerbose > 0 && ipmt % (fNPMTs / 10) == 0)
       	cout << "Finding nearest neighbours for PMT " << ipmt << " of " << fNPMTs << endl;
       pmt = fGeom->GetPMT(ipmt);
@@ -390,8 +421,9 @@ void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
 
       // loop over all PMTs and get the IDs of each ones that are closer that fNeighbourDistance
       neighbours.clear();
-      for (unsigned int jpmt = 0; jpmt < fNallPMTs; jpmt++) {
+      for (unsigned int jpmt = 0; jpmt < fNallPMTs_nomask; jpmt++) {
         if(jpmt == ipmt) continue; // don't count the current PMT itself
+        if(fMaskedPMTs[jpmt] || fMaskedPMTs[ipmt]) continue; // don't count masked PMTs
         if (jpmt < FIRST_PMT2)
           otherPMT = fGeom->GetPMT(jpmt);
         else

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -471,7 +471,7 @@ void WCSimFLOWER::GetNEff()
   fNEff *= liveAreaFraction;
   fNEffMod *= liveAreaFraction;
 
-  if(fVerbose) {
+  if(fVerbose > 0) {
     std::cout << endl << "***************************************" << endl
 	      << "nEff for this event: " << fNEff << endl
 	      << " (nEffMod for low photo-coverage is: " << fNEffMod << ")" << endl;

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -288,7 +288,7 @@ void WCSimFLOWER::FindMaxTimeInterval()
     }
   }//i
 
-  if(fVerbose)
+  if(fVerbose > 0)
     std::cout << "Maximum of " << fNMaxShort << " hits in " 
 	      << fShortDuration << " ns window starting at "
 	      << fStartTime << " ns" << std::endl

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -23,7 +23,8 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fVerbose(verbose),
     fGeom(geom),
     fLongDuration(100),
-    fShortDuration(50)
+    fShortDuration(50),
+    fQuiet(false)
 {
   switch (fDetector) {
   case kSuperK:
@@ -114,58 +115,58 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
 void WCSimFLOWER::SetDarkRate(float darkrate)
 {
   fDarkRate = darkrate;
-  cout << "Setting DarkRate to " << fDarkRate << " kHz" << endl;
+  if ( !fQuiet ) cout << "Setting DarkRate to " << fDarkRate << " kHz" << endl;
   fDarkRate /= 1000000; //convert to per ns
 }
 
 void WCSimFLOWER::SetDarkRate2(float darkrate)
 {
   fDarkRate2 = darkrate;
-  cout << "Setting DarkRate to " << fDarkRate2 << " kHz" << endl;
+  if ( !fQuiet ) cout << "Setting DarkRate to " << fDarkRate2 << " kHz" << endl;
   fDarkRate2 /= 1000000; //convert to per ns
 }
 
 void WCSimFLOWER::SetNPMTs(int npmts)
 {
   fNPMTs = npmts;
-  cout << "Setting NPMTs to " << fNPMTs << endl;
+  if ( !fQuiet ) cout << "Setting NPMTs to " << fNPMTs << endl;
 }
 
 void WCSimFLOWER::SetNPMTs2(int npmts)
 {
   fNPMTs2 = npmts;
-  cout << "Setting NPMTs2 to " << fNPMTs2 << endl;
+  if ( !fQuiet ) cout << "Setting NPMTs2 to " << fNPMTs2 << endl;
 }
 
 void WCSimFLOWER::SetNWorkingPMTs(int nworkingpmts)
 {
   fNWorkingPMTs = nworkingpmts;
-  cout << "Setting NWorkingPMTs to " << fNWorkingPMTs << endl;
+  if ( !fQuiet ) cout << "Setting NWorkingPMTs to " << fNWorkingPMTs << endl;
 }
 
 void WCSimFLOWER::SetNWorkingPMTs2(int nworkingpmts)
 {
   fNWorkingPMTs2 = nworkingpmts;
-  cout << "Setting NWorkingPMTs2 to " << fNWorkingPMTs2 << endl;
+  if ( !fQuiet ) cout << "Setting NWorkingPMTs2 to " << fNWorkingPMTs2 << endl;
 }
 
 void WCSimFLOWER::SetNeighbourDistance(float neighbour_distance, bool overwrite_nearest)
 {
   fNeighbourDistance = neighbour_distance;
-  cout << "Setting NeighbourDistance to " << fNeighbourDistance << endl;
+  if ( !fQuiet ) cout << "Setting NeighbourDistance to " << fNeighbourDistance << endl;
   GetNearestNeighbours(overwrite_nearest);
 }
 
 void WCSimFLOWER::SetShortDuration(float shortduration)
 {
   fShortDuration = shortduration;
-  cout << "Setting ShortDuration to " << fShortDuration << " ns" << endl;
+  if ( !fQuiet ) cout << "Setting ShortDuration to " << fShortDuration << " ns" << endl;
 }
 
 void WCSimFLOWER::SetLongDuration(float longduration)
 {
   fLongDuration = longduration;
-  cout << "Setting LongDuration to " << fLongDuration << " ns" << endl;
+  if ( !fQuiet ) cout << "Setting LongDuration to " << fLongDuration << " ns" << endl;
 }
 
 void WCSimFLOWER::SetTopBottomDistance(float hi, float lo)

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -356,7 +356,7 @@ void WCSimFLOWER::FindMaxTimeInterval()
     if(fTimesCorrected[i] >= fStartTime && fTimesCorrected[i] < (fStartTime + fShortDuration)) {
       fDistanceShort[j] = fDistance[i];
       fTubeIdsShort [j] = fTubeIds [i];
-      if (fTubeIdsShort[j] <= 0 || fTubeIdsShort[j] > fNallPMTs_nomask || (fTubeIdsShort[j] > fNPMTs_nomask && fTubeIdsShort[j] < FIRST_PMT2) 
+      if (fTubeIdsShort[j] <= 0 || fTubeIdsShort[j] > fNallPMTs_nomask || (fTubeIdsShort[j] > fNPMTs_nomask && fTubeIdsShort[j] < FIRST_PMT2)
          || fMaskedPMTs[fTubeIdsShort[j]] )
         cerr << "fTubeIdsShort has picked up an invalid ID: " << fTubeIdsShort[j] << endl
              << "Are you using the correct input file / geometry option combination" << endl;
@@ -428,13 +428,19 @@ void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
         if (jpmt < FIRST_PMT2) {
           if (jpmt >= fNPMTs_nomask ) continue; // this PMT doesn't exist
           otherPMT = fGeom->GetPMT(jpmt);
-          tubeID_j = otherPMT.GetTubeNo();
+          tubeID_j = otherPMT.GetTubeNo();	      
           if(fMaskedPMTs[tubeID_j]) continue; // don't count masked PMTs
         }
         else {
           otherPMT = fGeom->GetPMT(jpmt - FIRST_PMT2, true);
           tubeID_j = otherPMT.GetTubeNo();
           if(fMaskedPMTs[tubeID_j+FIRST_PMT2]) continue; // don't count masked PMTs
+        }
+
+        if (sqrt(pow(x - otherPMT.GetPosition(0), 2) + 
+                 pow(y - otherPMT.GetPosition(1), 2) +
+                 pow(z - otherPMT.GetPosition(2), 2)) < fNeighbourDistance) {
+          neighbours.push_back(tubeID_j);
         }
       }//jpmt
       fNeighbours[tubeID] = neighbours;

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -385,7 +385,7 @@ void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
       x = pmt.GetPosition(0);
       y = pmt.GetPosition(1);
       z = pmt.GetPosition(2);
-      if(fVerbose > 3 || ipmt <2)
+      if(fVerbose > 3)
 	      cout << "Tube " << tubeID << " x,y,z " << x << "," << y << "," << z << endl;
 
       // loop over all PMTs and get the IDs of each ones that are closer that fNeighbourDistance

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -409,8 +409,8 @@ void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
     float x, y, z;
     // Loop over 50cm PMTs to find their neighbours (don't search for neighbours of mPMTs, see https://github.com/HKDAQ/FLOWER/issues/12)
     for (unsigned int ipmt = 0; ipmt < fNPMTs_nomask; ipmt++) {        
-      if(fVerbose > 0 && ipmt % (fNPMTs / 10) == 0)
-      	cout << "Finding nearest neighbours for PMT " << ipmt << " of " << fNPMTs << endl;
+      if(fVerbose > 0 && ipmt % (fNPMTs_nomask / 10) == 0)
+      	cout << "Finding nearest neighbours for PMT " << ipmt << " of " << fNPMTs_nomask << endl;
       pmt = fGeom->GetPMT(ipmt);
       tubeID = pmt.GetTubeNo();
       x = pmt.GetPosition(0);
@@ -470,7 +470,7 @@ void WCSimFLOWER::GetNEff()
     z = pmt.GetPosition(2);
 
     // Calculate occupancy to correct for multiple hits on a single PMT
-    if (tubeID <= fNPMTs) {
+    if (tubeID <= fNPMTs_nomask) {
       nearbyHits = 0;
       neighbours = fNeighbours[tubeID];
       for(unsigned int j = 0; j < fNMaxShort; j++) {

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -410,7 +410,7 @@ void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
     float x, y, z;
     // Loop over 50cm PMTs to find their neighbours (don't search for neighbours of mPMTs, see https://github.com/HKDAQ/FLOWER/issues/12)
     for (unsigned int ipmt = 0; ipmt < fNPMTs_nomask; ipmt++) {        
-      if(fVerbose > 0 && ipmt % (fNPMTs_nomask / 10) == 0)
+      if(fVerbose && ipmt % (fNPMTs_nomask / 10) == 0)
       	cout << "Finding nearest neighbours for PMT " << ipmt << " of " << fNPMTs_nomask << endl;
       pmt = fGeom->GetPMT(ipmt);
       tubeID = pmt.GetTubeNo();

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -505,7 +505,7 @@ void WCSimFLOWER::CorrectEnergy()
     fERec = 1.0*fNEff + 0.0; // TODO: calibrate relation for this detector geometry
     break;
   }
-  if(fVerbose) {
+  if(fVerbose > 0) {
     std::cout << "Reconstructed energy = " << fERec << " MeV" << std::endl;
   }
 }

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -53,43 +53,43 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
     break;
-  case kHyperK20BnL0mPMT: // WCSim Hybrid 20% case
+  case kHyperK20BnL0mPMT: // WCSim Hybrid 20% case, result from 20k BL + 10k mPMTs with mask over 100% of 10k mPMT modules
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.; // dark rate of 7.5cm PMTs in mPMT modules
-    fNPMTs = 19418;   // total number of 50cm Box&Line PMTs
-    fNPMTs2 = 0; // total number of 7.5cm PMTs (10k mPMT modules, 19 PMTs each)
+    fNPMTs = 19208;   // total number of 50cm Box&Line PMTs
+    fNPMTs2 = 0; // total number of 7.5cm PMTs (0k mPMT modules, 19 PMTs each)
     fNeighbourDistance = 145;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
     break;
-  case kHyperK40BnL0mPMT:
+  case kHyperK40BnL0mPMT: // WCSim Hybrid 40% case
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.; // dark rate of 7.5cm PMTs in mPMT modules
     fNPMTs = 38952;   // total number of 50cm Box&Line PMTs
-    fNPMTs2 = 0; // total number of 7.5cm PMTs (10k mPMT modules, 19 PMTs each)
+    fNPMTs2 = 0; // total number of 7.5cm PMTs (0k mPMT modules, 19 PMTs each)
     fNeighbourDistance = 102;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
     break;
-  case kHyperK20BnL3mPMT:
+  case kHyperK20BnL3mPMT: // WCSim Hybrid 20% + 3k mPMT case, result from 20k BL + 10k mPMTs with mask over 70% of 10k mPMT modules
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.3; // dark rate of 7.5cm PMTs in mPMT modules
-    fNPMTs = 20055;   // total number of 50cm Box&Line PMTs
-    fNPMTs2 = 54131; // total number of 7.5cm PMTs (10k mPMT modules, 19 PMTs each)
+    fNPMTs = 19208;   // total number of 50cm Box&Line PMTs
+    fNPMTs2 = 54853; // total number of 7.5cm PMTs (3k mPMT modules, 19 PMTs each)
     fNeighbourDistance = 145;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
     break;
-  case kHyperK20BnL5mPMT:
+  case kHyperK20BnL5mPMT: // WCSim Hybrid 20% + 5k mPMT case, result from 20k BL + 10k mPMTs with mask over 50% of 10k mPMT modules
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.3; // dark rate of 7.5cm PMTs in mPMT modules
-    fNPMTs = 18952;   // total number of 50cm Box&Line PMTs
-    fNPMTs2 = 89604; // total number of 7.5cm PMTs (10k mPMT modules, 19 PMTs each)
+    fNPMTs = 19208;   // total number of 50cm Box&Line PMTs
+    fNPMTs2 = 91352; // total number of 7.5cm PMTs (5k mPMT modules, 19 PMTs each)
     fNeighbourDistance = 145;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
     break;
-  case kHyperK20BnL10mPMT:
+  case kHyperK20BnL10mPMT:  // WCSim Hybrid 20% + 10k mPMT case, result from 20k BL + 10k mPMTs with mask over 0% of 10k mPMT modules
     fDarkRate = 8.4;  // dark rate of 50cm Box&Line PMTs
     fDarkRate2 = 0.3; // dark rate of 7.5cm PMTs in mPMT modules
     fNPMTs = 19208;   // total number of 50cm Box&Line PMTs
@@ -494,7 +494,7 @@ void WCSimFLOWER::GetNEff()
     }
     if (fDetector == kHyperK20BnL5mPMT) {
       photoCoverage *= 38952 / float(fNPMTs); // ratio of number of B&L PMTs
-      photoCoverage /= 1.11; //  5k mPMT modules (19 PMTs, 3" diameter) have 22% the area of 18952 20-inch PMTs
+      photoCoverage /= 1.11; //  5k mPMT modules (19 PMTs, 3" diameter) have 11% the area of 18952 20-inch PMTs
     }
     if (fDetector == kHyperK20BnL10mPMT) {
       photoCoverage *= 38952 / float(fNPMTs); // ratio of number of B&L PMTs

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -67,7 +67,7 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool o
     fDarkRate2 = 0.; // dark rate of 7.5cm PMTs in mPMT modules
     fNPMTs = 38952;   // total number of 50cm Box&Line PMTs
     fNPMTs2 = 0; // total number of 7.5cm PMTs (10k mPMT modules, 19 PMTs each)
-    fNeighbourDistance = 145;
+    fNeighbourDistance = 102;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
     break;
@@ -385,7 +385,7 @@ void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
       x = pmt.GetPosition(0);
       y = pmt.GetPosition(1);
       z = pmt.GetPosition(2);
-      if(fVerbose > 3)
+      if(fVerbose > 3 || ipmt <2)
 	      cout << "Tube " << tubeID << " x,y,z " << x << "," << y << "," << z << endl;
 
       // loop over all PMTs and get the IDs of each ones that are closer that fNeighbourDistance

--- a/WCSimFLOWER.h
+++ b/WCSimFLOWER.h
@@ -39,7 +39,7 @@ class WCSimFLOWER {
   TString GetFLOWERDataDir();
 
  private:
-  enum kDetector_t {kSuperK = 0, kHyperK40, kHyperK20, kHyperK20BnL10mPMT};
+  enum kDetector_t {kSuperK = 0, kHyperK40, kHyperK20, kHyperK20BnL0mPMT, kHyperK40BnL0mPMT, kHyperK20BnL3mPMT, kHyperK20BnL5mPMT, kHyperK20BnL10mPMT};
 
   kDetector_t DetectorEnumFromString(std::string name);
   void CorrectHitTimes();

--- a/WCSimFLOWER.h
+++ b/WCSimFLOWER.h
@@ -65,7 +65,6 @@ class WCSimFLOWER {
   float    fTopBottomDistanceHi;
   float    fTopBottomDistanceLo;
   int       fVerbose;
-  bool       fQuiet;
 
   WCSimRootGeom * fGeom;
 

--- a/WCSimFLOWER.h
+++ b/WCSimFLOWER.h
@@ -19,7 +19,7 @@ using std::vector;
 class WCSimFLOWER {
 
  public:
-  WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool overwrite_nearest, int verbose);
+  WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool overwrite_nearest, int verbose, std::vector<bool> masked_pmt=std::vector<bool>());
   ~WCSimFLOWER() {};
 
   float GetEnergy(std::vector<float> times, std::vector<int> tubeIds, float * vertex);
@@ -57,8 +57,11 @@ class WCSimFLOWER {
   float    fDarkRate;
   float    fDarkRate2;
   int      fNallPMTs;
+  int      fNallPMTs_nomask;
   int       fNPMTs;
   int       fNPMTs2;
+  int       fNPMTs_nomask;
+  int       fNPMTs2_nomask;
   int       fNWorkingPMTs;
   int       fNWorkingPMTs2;
   float    fNeighbourDistance;
@@ -80,6 +83,8 @@ class WCSimFLOWER {
   float fNEffMod;
   float fERec;
 
+  vector<bool>   fMaskedPMTs;
+  
   vector<int>    fTubeIds;
   vector<float> fDistance;
   vector<float>  fTimes;

--- a/WCSimFLOWER.h
+++ b/WCSimFLOWER.h
@@ -35,6 +35,9 @@ class WCSimFLOWER {
   void SetShortDuration(float shortduration);
   void SetLongDuration(float longduration);
   void SetTopBottomDistance(float hi, float lo);
+  
+  inline void SetQuietMode(bool bQuiet) { fQuiet = bQuiet; }
+  inline void OverwriteNearestNeighbour() { GetNearestNeighbours(true); }
 
   TString GetFLOWERDataDir();
 
@@ -65,6 +68,7 @@ class WCSimFLOWER {
   float    fTopBottomDistanceHi;
   float    fTopBottomDistanceLo;
   int       fVerbose;
+  bool       fQuiet;
 
   WCSimRootGeom * fGeom;
 

--- a/WCSimFLOWER.h
+++ b/WCSimFLOWER.h
@@ -35,8 +35,6 @@ class WCSimFLOWER {
   void SetShortDuration(float shortduration);
   void SetLongDuration(float longduration);
   void SetTopBottomDistance(float hi, float lo);
-  
-  inline void OverwriteNearestNeighbour() { GetNearestNeighbours(true); }
 
   TString GetFLOWERDataDir();
 

--- a/WCSimFLOWER.h
+++ b/WCSimFLOWER.h
@@ -36,7 +36,6 @@ class WCSimFLOWER {
   void SetLongDuration(float longduration);
   void SetTopBottomDistance(float hi, float lo);
   
-  inline void SetQuietMode(bool bQuiet) { fQuiet = bQuiet; }
   inline void OverwriteNearestNeighbour() { GetNearestNeighbours(true); }
 
   TString GetFLOWERDataDir();


### PR DESCRIPTION
Add the possibility to load the list of masked PMT:
- Masked PMT are skipped when doing the neighbouring PMT lists.
- Max number of PMTs values are replaced by the values without mask applied for PMT Id checks in order to prevent issue. 
