### PR TITLE
Add ROOT File close() 

### DIFF
--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -394,6 +394,8 @@ void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
       if(fVerbose > 2)
 	      cout << "\tTube " << tubeID << " has " << neighbours->size() << " neighbours" << endl;
     }//ipmt
+    
+    f.Close();
   }//reading values
   else {
     if(fVerbose > 0)
@@ -451,6 +453,7 @@ void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
     }//ipmt
     t->Write();
     delete t;
+    f.Close();
   }//calculating values
   if(fVerbose > 1)
     cout << "GetNearestNeighbours() finished" << endl;

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -598,6 +598,18 @@ void WCSimFLOWER::CorrectEnergy()
       // use fNEffMod (with occupancy to power of 1.4)
       fERec = 0.000001148*pow(fNEffMod, 2) + 0.02032*fNEffMod + 1.94;
     break;
+  case kHyperK20BnL0mPMT: 
+    fERec = 1.0*fNEff + 0.0; // TODO: calibrate relation for this detector geometry
+    break;
+  case kHyperK40BnL0mPMT: 
+    fERec = 1.0*fNEff + 0.0; // TODO: calibrate relation for this detector geometry
+    break;
+  case kHyperK20BnL3mPMT: 
+    fERec = 1.0*fNEff + 0.0; // TODO: calibrate relation for this detector geometry
+    break;
+  case kHyperK20BnL5mPMT: 
+    fERec = 1.0*fNEff + 0.0; // TODO: calibrate relation for this detector geometry
+    break;
   case kHyperK20BnL10mPMT:
     fERec = 1.0*fNEff + 0.0; // TODO: calibrate relation for this detector geometry
     break;


### PR DESCRIPTION
I noticed in some rare cases, the Neighbouring PMT file is corrupted (ROOT complained about it not being correctly closed). 
The reason is not clear: It may be due to a crash of the program, to FLOWER not being correctly deleted in some occasions, or to the fact this root files is opened simultaneously by several different instance of FLOWER. 

Adding f.Close() after reading/writing the neighbouring PMTs seems to help the resolution of this issue.
