### PR TITLE
Use WCSIM_BUILD_DIR instead of WCSIMDIR for modern WCSim installation…

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ WCSIMLIBS     = -L$(WCSIM_BUILD_DIR)/lib -lWCSimRoot
 CPPFLAGS  += -Wno-deprecated 
 CPPFLAGS  += $(ROOTCFLAGS) $(WCSIMINCS)
 EXTRALIBS += $(ROOTLIBS) $(WCSIMLIBS)
-CXXFLAGS  += -g
+#CXXFLAGS  += -g
 
 CXX = g++
 #CXX = $(shell which g++)

--- a/Makefile
+++ b/Makefile
@@ -4,16 +4,16 @@
 
 ROOTCFLAGS   := $(shell root-config --cflags) -DUSE_ROOT -fPIC
 ROOTLIBS     := $(shell root-config --libs)
-ifndef WCSIMDIR
-$(error Environment variable WCSIMDIR is not set)
+ifndef WCSIM_BUILD_DIR
+$(error Environment variable WCSIM_BUILD_DIR is not set)
 endif
-WCSIMINCS     = -I$(WCSIMDIR)/include
-WCSIMLIBS     = -L$(WCSIMDIR) -lWCSimRoot
+WCSIMINCS     = -I$(WCSIM_BUILD_DIR)/include/WCSim
+WCSIMLIBS     = -L$(WCSIM_BUILD_DIR)/lib -lWCSimRoot
 
 CPPFLAGS  += -Wno-deprecated 
 CPPFLAGS  += $(ROOTCFLAGS) $(WCSIMINCS)
 EXTRALIBS += $(ROOTLIBS) $(WCSIMLIBS)
-#CXXFLAGS  += ""
+CXXFLAGS  += -g
 
 CXX = g++
 #CXX = $(shell which g++)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # FLOWER: soFtware for LOW-Energy Reconstruction
 An energy reconstruction script for low-energy events that works with (hk-)BONSAI and other low-energy reconstruction tools - it just requires a positional vertex.
 
-## Compiling
+## Compiling `WCSimFlower`
 Make sure the following are sourced
-* WCSim (`$WCSIMDIR` set)
+* WCSim (`$WCSIM_BUILD_DIR` set)
+  Note that the WCSim dependence of the `WCSimFlower` class is confined to geometry information.
 
 Then
 ```bash
@@ -11,9 +12,9 @@ export FLOWERDIR=/path/to/FLOWER
 make
 ```
 
-## Running the WCSim/BONSAI script bundled here
-Make sure the following are sourced
-* WCSim (`$WCSIMDIR` set)
+## Running the FLOWER/BONSAI script bundled here
+Make sure the following software is setup correctly
+* WCSim (`$WCSIM_BUILD_DIR` set)
 * BONSAI (`$BONSAIDIR` set)
 * FLOWER (`$FLOWERDIR` set)
 
@@ -27,7 +28,7 @@ rootflower -b -q flower_with_bonsai.C+'("/path/to/wcsim/file.root",1,"SuperK")'
 Note that `$FLOWERDATADIR` is used to store information that takes a while to calculate, and that only needs to be done once per geometry (e.g. the nearest neighbours of each PMT). If `$FLOWERDATADIR` is not set, or set to a directory that doesn't exist, `$FLOWERDIR/data/` will be used instead
 
 ## Running in other code
-* Construct a class member, giving it a detectorname (it sets default values and determines the exact energy correction factors) and detector geometry
+* Construct a class member, giving it a `detectorname` (it sets default values and determines the exact energy correction factors) and detector geometry
 ```
 WCSimFlower(const char * detectorname, WCSimRootGeom * geom, int verbose);
 ```

--- a/flower_with_bonsai.C
+++ b/flower_with_bonsai.C
@@ -15,7 +15,6 @@
 #include <TSystem.h>
 #include <TStopwatch.h>
 
-#if !defined(__CINT__) || defined(__MAKECINT__)
 //WCSim
 #include "WCSimRootEvent.hh"
 #include "WCSimRootGeom.hh"
@@ -23,7 +22,6 @@
 #include "WCSimBonsai.hh"
 //FLOWER
 #include "WCSimFLOWER.h"
-#endif
 
 // low energy reconstruction
 int flower_with_bonsai(const char *filename="../wcsim.root",
@@ -33,25 +31,6 @@ int flower_with_bonsai(const char *filename="../wcsim.root",
 {
 	// set up histogram
 	TH1F *recEnergy = new TH1F("hErec", "Reconstructed Energy", 50, 0, 100);
-
-#if !defined(__MAKECINT__)
-	// Load the library with class dictionary info (create with "gmake shared")
-	if (getenv ("WCSIMDIR") != NULL) {
-		gSystem->Load("${WCSIMDIR}/libWCSimRoot.so");
-	} else {
-		gSystem->Load("../WCSim/libWCSimRoot.so");
-	}
-	if (getenv ("BONSAIDIR") != NULL) {
-		gSystem->Load("${BONSAIDIR}/libWCSimBonsai.so");
-	} else {
-		gSystem->Load("../hk-BONSAI/libWCSimBonsai.so");
-	}
-	if (getenv ("FLOWERDIR") != NULL) {
-		gSystem->Load("${FLOWERDIR}/libWCSimFLOWER.so");
-	} else {
-		gSystem->Load("../FLOWER/libWCSimFLOWER.so");
-	}
-#endif
 
 	WCSimBonsai* bonsai = new WCSimBonsai();
 

--- a/rootflower/loadincs.C
+++ b/rootflower/loadincs.C
@@ -1,12 +1,12 @@
 {
-  TString wcsim_topdir   = gSystem->Getenv("WCSIMDIR");
+  TString wcsim_topdir   = gSystem->Getenv("WCSIM_BUILD_DIR");
   TString bonsai_topdir  = gSystem->Getenv("BONSAIDIR");
   TString flower_topdir = gSystem->Getenv("FLOWERDIR");
 
   TString mp = gROOT->GetMacroPath();
   TString ip;
 
-  TString wcsim_inc   = wcsim_topdir   + "/include";
+  TString wcsim_inc   = wcsim_topdir   + "/include/WCSim";
   TString bonsai_inc  = bonsai_topdir  + "/bonsai";
   TString flower_inc = flower_topdir;
 

--- a/rootflower/loadlibs.C
+++ b/rootflower/loadlibs.C
@@ -1,9 +1,10 @@
 {
   TString libs0  = gSystem->GetDynamicPath();
-  TString libswc = gSystem->Getenv("WCSIMDIR");
+  TString libswc = gSystem->Getenv("WCSIM_BUILD_DIR");
+  libswc += "/lib";
   TString libsb  = gSystem->Getenv("BONSAIDIR");
   TString libseb = gSystem->Getenv("FLOWERDIR");
-  TString libs   = libs0 + ":" + libseb + ":" + libsb + ":" + libswc + ":/usr/lib:/usr/local/lib:/opt/lib:/opt/local/lib";
+  TString libs   = libseb + ":" + libsb + ":" + libswc + ":" + libs0 + ":/usr/lib:/usr/local/lib:/opt/lib:/opt/local/lib";
   gSystem->SetDynamicPath(libs.Data());
 
   gSystem->Load("libGpad");

--- a/rootflower/rootflower.C
+++ b/rootflower/rootflower.C
@@ -54,7 +54,7 @@ void t2k_style()
 
   // use bold lines and markers
   t2kStyle->SetMarkerStyle(20);
-  t2kStyle->SetHistLineWidth(1.85);
+  t2kStyle->SetHistLineWidth(2);
   t2kStyle->SetLineStyleString(2,"[12 12]"); // postscript dashes
 
   // get rid of X error bars and y error bar caps
@@ -76,7 +76,8 @@ void t2k_style()
   //t2kStyle->SetStatStyle(0); //make stat boxes see through
   t2kStyle->SetStatBorderSize(0);
   t2kStyle->SetTextFont(42); //less bold
-
+  */
+  
   // Add a greyscale palette for 2D plots
   /*
   int ncol=50;


### PR DESCRIPTION
…s using cmake (since v1.11.0 in June 2023)