### PR TITLE
Quality of life improvements

### DIFF
--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -25,6 +25,9 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool g
     fLongDuration(100),
     fShortDuration(50)
 {
+  cout << endl << "******************" << endl
+       << "Inialising FLOWER" << endl
+       << "******************" << endl;
   switch (fDetector) {
   case kSuperK:
     fDarkRate = 4.2;
@@ -95,6 +98,8 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool g
   fTimesCorrectedSorted.reserve(fNPMTs);
 
   GetNearestNeighbours(overwrite_nearest);
+
+  cout << "******************" << endl;
 }
 
 void WCSimFLOWER::SetDarkRate(float darkrate)
@@ -496,18 +501,22 @@ bool WCSimFLOWER::CheckNearestNeighbours()
     cout << count.first << "\t" << count.second << endl;
 
     if(count.first <= 2) {
-      cerr << "Some PMTs have " << count.first << "neighbours. Increase neighbour distance & try again" << endl;
+      cerr << "Some PMTs have " << count.first << " neighbours. Increase neighbour distance & try again" << endl;
       success = false;
     }
     else if(count.first >= 12) {
-      cerr << "Some PMTs have " << count.first << "neighbours. Decrease neighbour distance & try again" << endl;
+      cerr << "Some PMTs have " << count.first << " neighbours. Decrease neighbour distance & try again" << endl;
       success = false;
     }
   }
 
-  auto it = std::max_element(counts.begin(), counts.end());
-  if(it->first != 8) {
-    cerr << "Most PMTs should have 8 neighbours. Mode number of elements is " << it->first << endl;
+  std::pair<unsigned int, int> mode(*(counts.begin()));
+  for(auto const& count : counts) {
+    if(count.second > mode.second)
+      mode = count;
+  }
+  if(mode.first != 8) {
+    cerr << "Most PMTs should have 8 neighbours. Mode number of elements is " << mode.first << endl;
     success = false;
   }
   

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -54,8 +54,10 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool g
     fDarkRate = 8.4;
     fNPMTs = 19746;
     fNeighbourDistance = 145;
-    fTopBottomDistanceLo = 2670;
-    fTopBottomDistanceHi = 2690;
+    //note that these are wide because there is an assymmetry in the PMT positions
+    // This still won't get the next row of PMTs, which are at -3179.352000000 & +3111.524000000
+    fTopBottomDistanceLo = 3180;
+    fTopBottomDistanceHi = 3260;
     break;
   default:
     cerr << "Unknown detector name " << fDetectorName << endl;

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -33,16 +33,23 @@ WCSimFLOWER::WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool g
     fTopBottomDistanceLo = 1767;
     fTopBottomDistanceHi = 1768;
     break;
-  case kHyperK40:
+  case kHyperK40Old:
     fDarkRate = 8.4;
     fNPMTs = 38448;
     fNeighbourDistance = 102;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
     break;
-  case kHyperK20:
+  case kHyperK20Old:
     fDarkRate = 8.4;
     fNPMTs = 19462;
+    fNeighbourDistance = 145;
+    fTopBottomDistanceLo = 2670;
+    fTopBottomDistanceHi = 2690;
+    break;
+  case kHyperKRealistic:
+    fDarkRate = 8.4;
+    fNPMTs = 19746;
     fNeighbourDistance = 145;
     fTopBottomDistanceLo = 2670;
     fTopBottomDistanceHi = 2690;
@@ -146,12 +153,14 @@ void WCSimFLOWER::SetTopBottomDistance(float hi, float lo)
 
 WCSimFLOWER::kDetector_t WCSimFLOWER::DetectorEnumFromString(std::string name)
 {
-  if(!name.compare("HyperK") || !name.compare("HyperK_40perCent"))
-    return kHyperK40;
+  if(!name.compare("HyperK") || !name.compare("HyperK_Realistic"))
+    return kHyperKRealistic;
+  else if(!name.compare("HyperK_40perCent_Old"))
+    return kHyperK40Old;
   else if(!name.compare("SuperK"))
     return kSuperK;
-  else if (!name.compare("HyperK_20perCent"))
-    return kHyperK20;
+  else if (!name.compare("HyperK_20perCent_Old"))
+    return kHyperK20Old;
   cerr << "DetectorEnumFromString() Unknown detector name: " << name << endl;
   exit(-1);
 }
@@ -390,8 +399,10 @@ void WCSimFLOWER::GetNEff()
                                                           // ... the coverage to the most likely value of 0.4 (i.e. theta < 40 degrees)
     
     photoCoverage = 1 / WCSimFLOWER::fEffCoverages[int(theta/10)];
-    if (fDetector == kHyperK20)
+    if (fDetector == kHyperK20Old)
       photoCoverage *= 38448/float(19462); // ratio of number of PMTs is not exactly 2
+    else if (fDetector == kHyperKRealistic)
+      photoCoverage *= 38448/float(fNPMTs); // ratio of number of PMTs is not exactly 2
 
     // correct for scattering in water
     waterTransparency = exp(fDistanceShort[i] / fLambdaEff);
@@ -434,13 +445,14 @@ void WCSimFLOWER::CorrectEnergy()
     else
       fERec = 0.0522*fNEff - 0.46;
     break;
-  case kHyperK40:
+  case kHyperK40Old:
     if (fNEff<1320)
       fERec = 0.02360*fNEff + 0.082;
     else
       fERec = 0.02524*fNEff - 2.081;
     break;
-  case kHyperK20:
+  case kHyperKRealistic:
+  case kHyperK20Old:
     if (fNEff<701)
       // use fNEff, as normal
       fERec = 0.00000255*pow(fNEff, 2) + 0.0215*fNEff + 0.429;

--- a/WCSimFLOWER.cpp
+++ b/WCSimFLOWER.cpp
@@ -285,7 +285,15 @@ void WCSimFLOWER::GetNearestNeighbours(bool overwrite_root_file)
     std::vector<int> * neighbours = 0;
     t->SetBranchAddress("neighbours", &neighbours);
     //loop over tree
-    for(long ipmt = 0; ipmt < t->GetEntries(); ipmt++) {
+    const int n_entries = t->GetEntries();
+    if(n_entries != fNPMTs) {
+      std::cerr << "Mismatch between number of PMTs FLOWER is assuming: " << fNPMTs
+		<< " and number of PMTs in the previously calculated nearest neighbours file: "
+		<< n_entries
+		<< " Exiting..." << endl;
+      exit(-1);
+    }
+    for(long ipmt = 0; ipmt < n_entries; ipmt++) {
       t->GetEntry(ipmt);
       fNeighbours[tubeID] = *neighbours;
       if(fVerbose > 2)

--- a/WCSimFLOWER.h
+++ b/WCSimFLOWER.h
@@ -40,7 +40,7 @@ class WCSimFLOWER {
   bool CheckNearestNeighbours();
 
  private:
-  enum kDetector_t {kSuperK = 0, kHyperK40, kHyperK20};
+  enum kDetector_t {kSuperK = 0, kHyperK40Old, kHyperK20Old, kHyperKRealistic};
 
   kDetector_t DetectorEnumFromString(std::string name);
   void CorrectHitTimes();

--- a/WCSimFLOWER.h
+++ b/WCSimFLOWER.h
@@ -19,7 +19,7 @@ using std::vector;
 class WCSimFLOWER {
 
  public:
-  WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool overwrite_nearest, int verbose);
+  WCSimFLOWER(const char * detectorname, WCSimRootGeom * geom, bool get_npmts_from_wcsimrootgeom, bool overwrite_nearest, int verbose);
   ~WCSimFLOWER() {};
 
   float GetEnergy(std::vector<float> times, std::vector<int> tubeIds, float * vertex);
@@ -34,6 +34,8 @@ class WCSimFLOWER {
   void SetTopBottomDistance(float hi, float lo);
 
   TString GetFLOWERDataDir();
+
+  bool CheckNearestNeighbours();
 
  private:
   enum kDetector_t {kSuperK = 0, kHyperK40, kHyperK20};
@@ -60,7 +62,8 @@ class WCSimFLOWER {
   int       fVerbose;
 
   WCSimRootGeom * fGeom;
-
+  bool fGetNPMTsFromWCSimRootGeom;
+  
   int    fNDigits;
   int    fNMaxShort;
   int    fNMaxLong;

--- a/WCSimFLOWER.h
+++ b/WCSimFLOWER.h
@@ -23,6 +23,8 @@ class WCSimFLOWER {
   ~WCSimFLOWER() {};
 
   float GetEnergy(std::vector<float> times, std::vector<int> tubeIds, float * vertex);
+  float RetrieveNEff() const {return fNEff;} ///< Get the effective number of hits. GetEnergy() should have already been called, in order to fill fNeff with a sensible value
+  float RetrieveNEff2() const {return fNEff2;} ///< Get the effective number of hits (second defintion). GetEnergy() should have already been called, in order to fill fNEff2 with a sensible value
 
   //override default values with these methods
   void SetDarkRate(float darkrate);

--- a/flower_with_bonsai.C
+++ b/flower_with_bonsai.C
@@ -238,7 +238,15 @@ int flower_with_bonsai(const char *detector, //sets the default nearest neighbou
 			float* bsQ_a = &bsQ[0];
 
 			if (verbose) std::cout << "Fitting event vertex with hk-BONSAI ..." << std::endl;
-			bonsai->BonsaiFit(bsVertex, bsResult, bsGood, bsNsel, bsNhit, bsCAB_a, bsT_a, bsQ_a);
+
+			try {
+			  bonsai->BonsaiFit(bsVertex, bsResult, bsGood, bsNsel, bsNhit, bsCAB_a, bsT_a, bsQ_a);
+			}
+			catch (int e) {
+			  std::cerr << "BONSAI threw an exception! Will fill the tree, then continue (not running FLOWER)" << std::endl;
+			  out_tree->Fill();
+			  continue;
+			}
 			if (verbose){
 			  std::cout << "Vertex found at:";
 			  for(int iv = 0; iv < 4; iv++)

--- a/flower_with_bonsai.C
+++ b/flower_with_bonsai.C
@@ -288,6 +288,9 @@ int flower_with_bonsai(const char *detector, //sets the default nearest neighbou
 		event->ReInitialize();
 	} // End of loop over events
 	timer.Print();
+	cout << "Average times:"
+	     << "\tCPU   " << timer.CpuTime() / tree->GetEntries() << endl
+	     << "\tReal  " << timer.RealTime() / tree->GetEntries() << endl;
 
 	outfile->cd();
 	out_tree->Write();

--- a/flower_with_bonsai.C
+++ b/flower_with_bonsai.C
@@ -27,6 +27,7 @@
 // low energy reconstruction
 int flower_with_bonsai(const char *detector, //sets the default nearest neighbour distances etc. Check DetectorEnumFromString inside WCSimFLOWER.cpp for allowed values
 		       const char *filename="../wcsim.root",
+		       const char *outfiletag="", //output file for input file.root will be in the format file_flower_bonsai<outfiletag>.root
 		       const int  verbose=1,
 		       const bool overwrite_nearest = false, //if true, will overwrite the cached nearest neighbours file
 		       const double override_dark_rate = -99 //if positive, will override the default dark rate (taken from WCSimRootOptions)
@@ -37,12 +38,43 @@ int flower_with_bonsai(const char *detector, //sets the default nearest neighbou
 
 	WCSimBonsai* bonsai = new WCSimBonsai();
 
-	// Open the ROOT file
+	// Open the input ROOT file
 	TFile *file = new TFile(filename,"read");
 	if (!file->IsOpen()) {
 		std::cout << "ERROR: Could not open input file " << filename << std::endl;
 		return -1;
 	}
+
+	// Open the output ROOT file & create a TTree
+	//Note that this is a flat tree that will be filled every trigger,
+	// such that if you have an input file with multiple triggers,
+	// some information (e.g. true_* variables) will be repeated
+	TString outfilename(filename);
+	outfilename.ReplaceAll(".root", TString::Format("_bonsai_flower%s.root", outfiletag));
+	TFile *outfile = new TFile(outfilename, "RECREATE");
+	TTree * out_tree = new TTree("lowEreco", "FLOWER & BONSAI reconstruction (setup for events with 1 primary track & 1 trigger)");
+	//setup true variables
+	TVector3 true_pos, true_dir;
+	double   true_time;
+	float    true_energy;
+	out_tree->Branch("true_position", &true_pos);
+	out_tree->Branch("true_direction", &true_dir);
+	out_tree->Branch("true_time", &true_time, "true_time/D");
+	out_tree->Branch("true_energy", &true_energy, "true_time/F");
+	//setup reco variables
+	TVector3 reco_pos, reco_dir;
+	double   reco_time;
+	float    reco_energy, reco_neff, reco_neff2;
+	out_tree->Branch("reco_position", &reco_pos);
+	out_tree->Branch("reco_direction", &reco_dir);
+	out_tree->Branch("reco_time", &reco_time, "reco_time/D");
+	out_tree->Branch("reco_energy", &reco_energy, "reco_energy/F");
+	out_tree->Branch("reco_neff", &reco_neff, "reco_neff/F");
+	out_tree->Branch("reco_neff2", &reco_neff2, "reco_neff2/F");
+	//setup hit variables
+	int nhits, ndigits;
+	out_tree->Branch("nhits", &nhits, "nhits/I");
+	out_tree->Branch("ndigits", &ndigits, "ndigits/I");
 
 	// Read geometry from WCSim file
 	TTree *geotree = (TTree*)file->Get("wcsimGeoT");
@@ -73,7 +105,7 @@ int flower_with_bonsai(const char *detector, //sets the default nearest neighbou
 	  cerr << "Nearest neighbour distribution failure. Set nearest neighbour and try again" << endl;
 	  exit(8);
 	}
-	  
+
 	//Read event tree from WCSim file
 	TTree *tree = (TTree*)file->Get("wcsimT"); // Get a pointer to the tree from the file
 	WCSimRootEvent* event = new WCSimRootEvent(); // Create WCSimRootEvent to put stuff from the tree in
@@ -93,14 +125,81 @@ int flower_with_bonsai(const char *detector, //sets the default nearest neighbou
 	cout << "Starting timer for the event loop" << endl;
 	TStopwatch timer;
 	for (int ev=0; ev < tree->GetEntries(); ev++) {
+
+	  //reset tree variables
+	  true_pos.SetXYZ(-9999,-9999,-9999);
+	  true_dir.SetXYZ(-99,-99,-99);
+	  true_time = -9999;
+	  true_energy = -99;
+	  reco_pos.SetXYZ(-9999,-9999,-9999);
+	  reco_dir.SetXYZ(-99,-99,-99);
+	  reco_time = -9999;
+	  reco_energy = -99;
+	  reco_neff = -99;
+	  reco_neff2 = -99;
+	  nhits = -99;
+	  ndigits = -99;
+	  
 		if (verbose) std::cout << "event number: " << ev << std::endl;
 
 		// Read the event from the tree into the WCSimRootEvent instance
 		tree->GetEntry(ev);
 		trigger = event->GetTrigger(0);
 
+		//get the hits & digits
+		nhits = trigger->GetNcherenkovhits();
+
 		// See chapter 5 of doc/DetectorDocumentation.pdf in the WCSim repository
 		// for more information on the structure of the root file.
+
+		//get true vertex information
+		true_pos.SetXYZ(trigger->GetVtx(0), trigger->GetVtx(1), trigger->GetVtx(2));
+		true_time = trigger->GetHeader()->GetDate();
+
+		//get true track information
+		const int ntracks = trigger->GetNtrack();
+		for(int itrack = 0; itrack < ntracks; itrack++) {
+		  TObject *element = (trigger->GetTracks())->At(itrack);
+		  if(!element)
+		    continue;
+		  WCSimRootTrack *wcsimroottrack = dynamic_cast<WCSimRootTrack*>(element);
+
+		  if(verbose > 1){
+		    cout<<"Track: "<<itrack<<endl << "  ";
+		    int trackflag = wcsimroottrack->GetFlag();
+		    if(trackflag==-1) cout<<"Primary neutrino track"<<endl;
+		    else if(trackflag==-2) cout<<"Neutrino target nucleus track"<<endl;
+		    else cout<<"Final state particle track"<<endl;
+		    printf("  Track ipnu (PDG code): %d\n",wcsimroottrack->GetIpnu());
+		    printf("  PDG code of parent particle (0 for primary): %d\n",wcsimroottrack->GetParenttype());
+            
+		    cout<<"  Track initial dir [unit 3-vector]: ("
+			<<wcsimroottrack->GetDir(0)<<", "
+			<<wcsimroottrack->GetDir(1)<<", "
+			<<wcsimroottrack->GetDir(2)<<")"<<endl;
+		    printf("  Track initial relativistic energy [MeV]: %f\n", wcsimroottrack->GetE());
+		    printf("  Track initial momentum magnitude [MeV/c]: %f\n", wcsimroottrack->GetP());
+		    printf("  Track mass [MeV/c2]: %f\n", wcsimroottrack->GetM());
+		    printf("  Track ID: %d\n", wcsimroottrack->GetId());
+		    printf("  Number of ID/OD crossings: %zu\n", wcsimroottrack->GetBoundaryPoints().size());
+		    if (wcsimroottrack->GetBoundaryPoints().size()>0)
+		      printf("  First crossing position [mm]: (%f %f %f), KE [MeV]: %f, time [ns]: %f, type: %d\n", 
+			     wcsimroottrack->GetBoundaryPoints().at(0).at(0),
+			     wcsimroottrack->GetBoundaryPoints().at(0).at(1),
+			     wcsimroottrack->GetBoundaryPoints().at(0).at(2),
+			     wcsimroottrack->GetBoundaryKEs().at(0),
+			     wcsimroottrack->GetBoundaryTimes().at(0),
+			     wcsimroottrack->GetBoundaryTypes().at(0)
+			     );
+		  }//verbose
+
+		  //find the primary particle
+		  if(wcsimroottrack->GetId() == 1 && wcsimroottrack->GetParenttype() == 0) {
+		    true_dir.SetXYZ(wcsimroottrack->GetDir(0), wcsimroottrack->GetDir(1), wcsimroottrack->GetDir(2));
+		    true_energy = wcsimroottrack->GetE();
+		    break;
+		  }
+		}//itrack
 
 		// Loop over triggers in the event
 		for (int index = 0 ; index < event->GetNumberOfEvents(); index++) {
@@ -116,6 +215,9 @@ int flower_with_bonsai(const char *detector, //sets the default nearest neighbou
 			std::vector<int> bsCAB (ncherenkovdigihits,0);
 
 			bsNhit = & ncherenkovdigihits;
+
+			//fill the tree variable
+			ndigits = ncherenkovdigihits;
 
 			// Get time, charge and PMT number for each hit
 			for (i=0; i<ncherenkovdigihits; i++) {
@@ -158,10 +260,20 @@ int flower_with_bonsai(const char *detector, //sets the default nearest neighbou
 			// PID (i.e. electron vs. positron) and absolute time (as opposed to time relative to the trigger window) are not available.
 			std::cout << "t, PID, " << eRec << ", " << x << ", " << y << ", " << z << ", " << bsVertex[0] << ", " << bsVertex[1] << ", " << bsVertex[2] << std::endl;
 
+			//fill the reconstructed tree variables
+			reco_pos.SetXYZ(bsVertex[0], bsVertex[1], bsVertex[2]);
+			reco_dir.SetXYZ(x, y, z);
+			reco_time = bsVertex[3];
+			reco_energy = eRec;
+			reco_neff = flower->RetrieveNEff();
+			reco_neff2 = flower->RetrieveNEff2();
+
 			// Free the memory used by these vectors
 			std::vector<int>().swap(bsCAB);
 			std::vector<float>().swap(bsT);
 			std::vector<float>().swap(bsQ);
+
+			out_tree->Fill();
 		} // End of loop over triggers in event
 
 		// reinitialize event between loops
@@ -169,6 +281,9 @@ int flower_with_bonsai(const char *detector, //sets the default nearest neighbou
 	} // End of loop over events
 	timer.Print();
 
+	outfile->cd();
+	out_tree->Write();
+	
 	// display histogram(s)
 	float winScale = 0.75;
 	int nWide = 1;

--- a/tuning/compare_resolution.C
+++ b/tuning/compare_resolution.C
@@ -1,0 +1,131 @@
+#include "TChain.h"
+#include "TFile.h"
+#include "TChain.h"
+#include "TH1F.h"
+#include "TCanvas.h"
+#include "TMath.h"
+#include "TString.h"
+#include "TPaveStats.h"
+#include "TStyle.h"
+#include "TF1.h"
+
+#include <iostream>
+#include <vector>
+
+void MoveStat(TH1F * h,
+	      const float x1, const float y1,
+	      const float x2, const float y2,
+	      const Color_t text_colour)
+{
+  h->GetListOfFunctions()->Print();
+  TPaveStats * s = (TPaveStats*)h->GetListOfFunctions()->FindObject("stats");
+  if(s != nullptr) {
+    s->SetX1NDC(x1);
+    s->SetY1NDC(y1);
+    s->SetX2NDC(x2);
+    s->SetY2NDC(y2);
+    s->SetTextColor(text_colour);
+  }
+
+  h->GetFunction("gaus")->SetLineColor(text_colour);
+}
+
+TH1F * get_resolution(const char * filename,
+		      const char * treename,
+		      const char * var_opt,
+		      const char * hname,
+		      const char * binning,
+		      const char * cut_opt,
+		      const char * units,
+		      const char * draw_opt,
+		      const Color_t colour
+		      )
+{
+  TChain * t = new TChain(treename);
+  const int nfiles = t->Add(filename);
+  if(nfiles < 1) {
+    cerr << "Could not open tree: " << treename << " in files: " << filename << endl;
+    exit(-1);
+  }
+  const int total_entries = t->GetEntries();
+  const int cut_entries = t->GetEntries(cut_opt);
+  cout << nfiles << " files from " << filename << " added to TChain " << treename << endl
+       << "Chain has " << total_entries << " total entries" << endl
+       << cut_entries << " after cut(s)" << endl
+       << total_entries - cut_entries << " outside cuts = "
+       << 100. * (total_entries - cut_entries) / total_entries << "%" << endl;
+  
+  TString full_var_exp = TString::Format("(%s)>>%s%s", var_opt, hname, binning);
+  TString full_draw_opt = TString::Format("%s", draw_opt);
+  cout << endl
+       << "Drawing: " << full_var_exp << endl
+       << "    Cut: " << cut_opt << endl
+       << "   Draw: " << full_draw_opt << endl;
+  const int nentries = t->Draw(full_var_exp, cut_opt, full_draw_opt);
+  cout << "Plot has " << nentries << " entries" << endl;
+  return nullptr;
+  auto htemp = (TH1F*)gPad->GetPrimitive(hname); // 1D
+  htemp->SetTitle(TString::Format(";%s %s;Number in bin", var_opt, units));
+
+  htemp->SetLineWidth(2);
+  htemp->SetLineColor(colour);
+  htemp->SetMarkerColor(colour);
+  cout << htemp->GetMarkerSize() << endl << endl;
+
+  for(int ix = 1; ix < htemp->GetNbinsX(); ix++) {
+    htemp->SetBinError(ix, TMath::Sqrt(htemp->GetBinContent(ix)));
+  }
+
+  return htemp;
+}
+
+void compare_resolution_one(float energy = 10,
+			    const char * resolution = "true_energy-reco_energy",
+			    const char * units = "(MeV)")
+{
+  gStyle->SetOptFit(0111);
+  
+  TCanvas * c = new TCanvas();
+  c->SetTopMargin(0.2);
+  c->SetLeftMargin(0.15);
+  TH1F * h1 = get_resolution(TString::Format("%.1f/wcsim_output_%.1f_*_bonsai_flower_oldB_oldF.root", energy, energy), "lowEreco",
+			     resolution, "Old Tune", "", "reco_energy > -98", units, "", kBlack);
+  if(h1 == nullptr)
+    return;
+  TH1F * h2 = get_resolution(TString::Format("%.1f/wcsim_output_%.1f_*_bonsai_flower_oldB_oldF.root", energy, energy), "lowEreco",
+			     resolution, "New Tune", "", "reco_energy > -98", units, "SAME", kRed);
+  if(h2 == nullptr)
+    return;
+  c->BuildLegend(0.2, 0.8, 0.5, 1.0);
+
+  h1->Fit("gaus");
+  MoveStat(h1, 0.50, 0.8, 0.75, 1, kBlack);
+  h2->Fit("gaus");
+  MoveStat(h2, 0.75, 0.8, 1.00, 1,  kRed);
+}
+
+void compare_resolution()
+{
+  vector<float> energies = {10};
+  
+  std::vector<std::pair<string, string> > resolutions;
+  resolutions.push_back(std::make_pair("true_energy-reco_energy", "MeV"));
+  resolutions.push_back(std::make_pair("true_direction.Angle(reco_direction)", "degrees??"));
+  resolutions.push_back(std::make_pair("(true_position-reco_position).Mag()", "cm??"));
+  resolutions.push_back(std::make_pair("true_position.X()-reco_position.X()", "cm??"));
+  resolutions.push_back(std::make_pair("true_position.Y()-reco_position.Y()", "cm??"));
+  resolutions.push_back(std::make_pair("true_position.Z()-reco_position.Z()", "cm??"));
+  resolutions.push_back(std::make_pair("true_time-reco_time", "s???"));
+  
+  for(const auto resolution : resolutions) {
+    for(const auto energy : energies) {
+      compare_resolution_one(energy, resolution.first.c_str(), resolution.second.c_str());
+    }//energies
+  }//resolutions
+
+  cerr << "TODOOOOOOOOO" << endl
+       << " Get direction & position magnitude plots working" << endl
+       << " Get fit box working (I presume need to create a function)" << endl
+       << " Fix units" << endl
+       << " Make summary plots (as a function of energy)" << endl;
+}


### PR DESCRIPTION
- Make detector a required argument of `flower_with_bonsai.C`
- New option to get NPMTs from WCSimRootGeom
- Default option to get PMT dark rate from WCSimRootOptions (can override with macro argument)
- New CheckNearestNeighbours() method for testing distances in new geometries
- Ensure the nearest neighbours file you're reading in has the right number of PMTs in it
- Add way to get fNEff & fNEff2 (required for tuning)
- Add new enumeration for new HK detector geometry (tune will come in a new PR)
- `flower_with_bonsai.C` now produces a TTree with reconstruction results
- `flower_with_bonsai.C` safely handles BONSAI exceptions